### PR TITLE
Separated GitHub pull in seperate thread for task 123

### DIFF
--- a/src/main/java/memoranda/CurrentProject.java
+++ b/src/main/java/memoranda/CurrentProject.java
@@ -82,11 +82,13 @@ public class CurrentProject {
     }
     
     public static CommitList getCommitList() {
-            return _commits;
+        // Reopen in case it's been saved since we last got it.
+        return CurrentStorage.get().openCommitList(_project);
     }
     
     public static PullRequestList getPullRequestList() {
-            return _pullRequests;
+        // Reopen in case it's been saved since we last got it.
+        return CurrentStorage.get().openPullRequestList(_project);
     }
 
     public static void set(Project project) {
@@ -136,8 +138,12 @@ public class CurrentProject {
         storage.storeNoteList(_notelist, _project);
         storage.storeTaskList(_tasklist, _project); 
         storage.storeResourcesList(_resources, _project);
+        /* Storage will be handle by the GitHubRunnable thread that pulls the 
+         * data so it doesn't get overwritten. This class can read, just never
+         * write this data.
         storage.storeCommitList(_commits, _project);
         storage.storePullRequestList(_pullRequests, _project);
+        */
         storage.storeProjectManager();
     }
     

--- a/src/main/java/memoranda/ProjectImpl.java
+++ b/src/main/java/memoranda/ProjectImpl.java
@@ -22,6 +22,8 @@ import main.java.memoranda.date.CalendarDate;
 import main.java.memoranda.date.CurrentDate;
 import main.java.memoranda.util.Commit;
 import main.java.memoranda.util.Contributor;
+import main.java.memoranda.util.CurrentStorage;
+import main.java.memoranda.util.GitHubRunnable;
 import main.java.memoranda.util.JsonApiClass;
 import main.java.memoranda.util.PullRequest;
 import main.java.memoranda.util.Util;
@@ -282,26 +284,8 @@ public class ProjectImpl implements Project {
      */
     public void addCommitData(String repo) {
         try {
-            int code = 0;
-        	URL url = new URL("https://github.com/"+ repo);
-            HttpURLConnection huc = (HttpURLConnection) url.openConnection();
-            huc.setRequestMethod("GET");
-            huc.connect();
-            code = huc.getResponseCode();
-            JAC = new JsonApiClass(new URL("https://api.github.com/repos/" + repo), true);
-            List<Commit> commits = JAC.getCommitsArrLst();
-            CommitList cl = CurrentProject.getCommitList();
-            for (int i = 0; i < commits.size(); i++) {
-                cl.addCommit(commits.get(i));
-            }
-            
-            // TODO probably need to move this to addPullRequest or something like that
-            List<PullRequest> pullRequests = JAC.getPullRequests();
-            PullRequestList prl = CurrentProject.getPullRequestList();
-            for (int i = 0; i < pullRequests.size(); i++) {
-                prl.addPullRequest(pullRequests.get(i));
-            }
-            
+            (new Thread(new GitHubRunnable(
+                    repo, CurrentStorage.get(), CurrentProject.get()))).start();
         }
         catch (Exception ex) {
             Util.debug(ex.getMessage());

--- a/src/main/java/memoranda/util/CommitsGenerator.java
+++ b/src/main/java/memoranda/util/CommitsGenerator.java
@@ -10,6 +10,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.Enumeration;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Vector;
 
@@ -509,24 +510,14 @@ String footer = "</table></body></html>";
 	    //el.addAttribute(new Attribute("names", ""));
 	    //el.addAttribute(new Attribute("gitnames", ""));
 		//Project y = new ProjectImpl(el);
-		Project y = CurrentProject.get();
+		//Project y = CurrentProject.get();
 		//System.out.println("[Debug] Current project: " + y.getTitle());
-		JsonApiClass currentProjectJSON = y.getProjectJsonApiClass();
+		//JsonApiClass currentProjectJSON = y.getProjectJsonApiClass();
 		//System.out.println("[Debug] Current project json: " + currentProjectJSON);
 		
     	// Get all commits from the current project's JsonApiClass. 
 		//ArrayList<Commit> listOfAllCommits = currentProjectJSON.getCommitsArrLst();	// old commented out.
-    	Vector<Commit> listOfAllCommits = new Vector<>();
-    	try {
-        	listOfAllCommits = currentProjectJSON.getCommitsArrLst();
-        }
-        catch (NullPointerException e) {
-        	System.out.println("[DEBUG] No commits for selected project.");
-        }
-        // If there are no commits, just return. 
-        if (listOfAllCommits == null) {
-        	return "";
-        }
+    	List<Commit> listOfAllCommits = CurrentProject.getCommitList().getAllCommits();
         // If the Array List is empty, just return.
         if (listOfAllCommits.isEmpty()) {
         	return "";

--- a/src/main/java/memoranda/util/GitHubRunnable.java
+++ b/src/main/java/memoranda/util/GitHubRunnable.java
@@ -1,0 +1,56 @@
+package main.java.memoranda.util;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.List;
+
+import main.java.memoranda.CommitList;
+import main.java.memoranda.CurrentProject;
+import main.java.memoranda.Project;
+import main.java.memoranda.PullRequestList;
+
+import org.json.JSONException;
+
+
+public class GitHubRunnable implements Runnable {
+    String repo;
+    Storage storage;
+    Project project;
+    
+    public GitHubRunnable(String gitHubRepo, Storage store, Project prj) {
+        repo = gitHubRepo;
+        storage = store;
+        project = prj;
+    }
+    
+    /**
+     * Builds a JsonApiClass and updates all the current project data.
+     */
+    public void run() {
+        // build JSON API getter
+        JsonApiClass jac = null;
+        try {
+            jac = new JsonApiClass(new URL("https://api.github.com/repos/" + repo), true);
+        } catch (JSONException | IOException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
+        
+        // Build commits
+        List<Commit> commits = jac.getCommitsArrLst();
+        
+        CommitList cl = storage.openCommitList(project);
+        for (int i = 0; i < commits.size(); i++) {
+            cl.addCommit(commits.get(i));
+        }
+        storage.storeCommitList(cl, project);
+        
+        // Build pull requests
+        List<PullRequest> pullRequests = jac.getPullRequests();
+        PullRequestList prl = storage.openPullRequestList(project);
+        for (int i = 0; i < pullRequests.size(); i++) {
+            prl.addPullRequest(pullRequests.get(i));
+        }
+        storage.storePullRequestList(prl, project);
+    }
+}


### PR DESCRIPTION
Task 123 and 164 included in this. JAC pulls in separate thread now. File storage had to change as a result to prevent over-writing as well as making sure we write to the correct project. Additionally the commit panel will now pull from the stored list, not from a JAC.